### PR TITLE
Tuple fix

### DIFF
--- a/exponax/nonlin_fun/_general_nonlinear.py
+++ b/exponax/nonlin_fun/_general_nonlinear.py
@@ -18,7 +18,7 @@ class GeneralNonlinearFun(BaseNonlinearFun):
         *,
         derivative_operator: Complex[Array, "D ... (N//2)+1"],
         dealiasing_fraction: float,
-        scale_list: tuple[float, ...] = [0.0, -1.0, 0.0],
+        scale_list: tuple[float, float, float] = (0.0, -1.0, 0.0),
         zero_mode_fix: bool = True,
     ):
         """

--- a/exponax/stepper/generic/_nonlinear.py
+++ b/exponax/stepper/generic/_nonlinear.py
@@ -11,7 +11,7 @@ from ._utils import (
 
 class GeneralNonlinearStepper(BaseStepper):
     coefficients_linear: tuple[float, ...]
-    coefficients_nonlinear: tuple[float, 3]
+    coefficients_nonlinear: tuple[float, float, float]
     dealiasing_fraction: float
 
     def __init__(
@@ -22,7 +22,7 @@ class GeneralNonlinearStepper(BaseStepper):
         dt: float,
         *,
         coefficients_linear: tuple[float, ...] = (0.0, 0.0, 0.01),
-        coefficients_nonlinear: tuple[float, 3] = (0.0, -1.0, 0.0),
+        coefficients_nonlinear: tuple[float, float, float] = (0.0, -1.0, 0.0),
         order=2,
         dealiasing_fraction: float = 2 / 3,
         num_circle_points: int = 16,
@@ -156,7 +156,7 @@ class GeneralNonlinearStepper(BaseStepper):
 
 class NormalizedNonlinearStepper(GeneralNonlinearStepper):
     normalized_coefficients_linear: tuple[float, ...]
-    normalized_coefficients_nonlinear: tuple[float, ...]
+    normalized_coefficients_nonlinear: tuple[float, float, float]
 
     def __init__(
         self,
@@ -164,7 +164,11 @@ class NormalizedNonlinearStepper(GeneralNonlinearStepper):
         num_points: int,
         *,
         normalized_coefficients_linear: tuple[float, ...] = (0.0, 0.0, 0.1 * 0.1),
-        normalized_coefficients_nonlinear: tuple[float, ...] = (0.0, -1.0 * 0.1, 0.0),
+        normalized_coefficients_nonlinear: tuple[float, float, float] = (
+            0.0,
+            -1.0 * 0.1,
+            0.0,
+        ),
         order=2,
         dealiasing_fraction: float = 2 / 3,
         num_circle_points: int = 16,
@@ -271,7 +275,7 @@ class NormalizedNonlinearStepper(GeneralNonlinearStepper):
 
 class DifficultyNonlinearStepper(NormalizedNonlinearStepper):
     linear_difficulties: tuple[float, ...]
-    nonlinear_difficulties: tuple[float, ...]
+    nonlinear_difficulties: tuple[float, float, float]
 
     def __init__(
         self,
@@ -283,7 +287,7 @@ class DifficultyNonlinearStepper(NormalizedNonlinearStepper):
             0.0,
             0.1 * 0.1 / 1.0 * 48**2 * 2,
         ),
-        nonlinear_difficulties: tuple[float, ...] = (
+        nonlinear_difficulties: tuple[float, float, float] = (
             0.0,
             -1.0 * 0.1 / 1.0 * 48,
             0.0,

--- a/exponax/stepper/generic/_utils.py
+++ b/exponax/stepper/generic/_utils.py
@@ -448,7 +448,7 @@ def extract_normalized_gradient_norm_scale_from_difficulty(
 
 
 def reduce_normalized_nonlinear_scales_to_difficulty(
-    normalized_nonlinear_scales: tuple[float],
+    normalized_nonlinear_scales: tuple[float, float, float],
     *,
     num_spatial_dims: int,
     num_points: int,
@@ -501,7 +501,7 @@ def reduce_normalized_nonlinear_scales_to_difficulty(
 
 
 def extract_normalized_nonlinear_scales_from_difficulty(
-    nonlinear_difficulties: tuple[float],
+    nonlinear_difficulties: tuple[float, float, float],
     *,
     num_spatial_dims: int,
     num_points: int,

--- a/exponax/stepper/reaction/_belousov_zhabotinsky.py
+++ b/exponax/stepper/reaction/_belousov_zhabotinsky.py
@@ -47,7 +47,7 @@ class BelousovZhabotinskyNonlinearFun(BaseNonlinearFun):
 
 
 class BelousovZhabotinsky(BaseStepper):
-    diffusivities: tuple[float, 3]
+    diffusivities: tuple[float, float, float]
     dealiasing_fraction: float
 
     def __init__(
@@ -57,7 +57,7 @@ class BelousovZhabotinsky(BaseStepper):
         num_points: int,
         dt: float,
         *,
-        diffusivities: tuple[float, 3] = (1e-5, 2e-5, 1e-5),
+        diffusivities: tuple[float, float, float] = (1e-5, 2e-5, 1e-5),
         order: int = 2,
         dealiasing_fraction: float = 1
         / 2,  # Needs lower value due to cubic nonlinearity


### PR DESCRIPTION
Correctly uses `tuple[float, float, float]` instead of `tuple[float, 3]` if the argument is supposed to be a tuple of three floats.