### PR TITLE
Small Improvements to Gaussian Random Field

### DIFF
--- a/exponax/ic/_gaussian_random_field.py
+++ b/exponax/ic/_gaussian_random_field.py
@@ -64,6 +64,9 @@ class GaussianRandomField(BaseRandomICGenerator):
             self.num_spatial_dims, self.domain_extent, num_points
         )
         wavenumer_norm_grid = jnp.linalg.norm(wavenumber_grid, axis=0, keepdims=True)
+        # Further division by 2.0 in the exponent is because we want to have the
+        # **power-spectrum** follow a **power-law**. See
+        # https://github.com/Ceyron/exponax/issues/9 for more details.
         amplitude = jnp.power(wavenumer_norm_grid, -self.powerlaw_exponent / 2.0)
         amplitude = (
             amplitude.flatten().at[0].set(1.0).reshape(wavenumer_norm_grid.shape)

--- a/exponax/ic/_gaussian_random_field.py
+++ b/exponax/ic/_gaussian_random_field.py
@@ -66,7 +66,7 @@ class GaussianRandomField(BaseRandomICGenerator):
         wavenumer_norm_grid = jnp.linalg.norm(wavenumber_grid, axis=0, keepdims=True)
         amplitude = jnp.power(wavenumer_norm_grid, -self.powerlaw_exponent / 2.0)
         amplitude = (
-            amplitude.flatten().at[0].set(0.0).reshape(wavenumer_norm_grid.shape)
+            amplitude.flatten().at[0].set(1.0).reshape(wavenumer_norm_grid.shape)
         )
 
         real_key, imag_key = jr.split(key, 2)


### PR DESCRIPTION
1. Sets the amplitude modifier of the power-law for the mean mode to `1.0` to retain the mean energy from the original white noise.
2. Adds a comment on why there is a `2.0` in the denominator of the power-law as detailed in #9 