### PR TITLE
Remove polyfill script from mkdocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,6 @@ markdown_extensions:
 
 extra_javascript:
     - javascripts/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
Currently, the `polyfill` will create  an unnecessary login request for your documentation page. Most importantly, `polyfill` has a severe security issue (https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/).